### PR TITLE
Use Github packages for private gem registry [IN-181]

### DIFF
--- a/lib/signature/version.rb
+++ b/lib/signature/version.rb
@@ -1,3 +1,3 @@
 module Signature
-  VERSION = "0.1.8"
+  VERSION = "0.1.9"
 end

--- a/signature.gemspec
+++ b/signature.gemspec
@@ -12,6 +12,9 @@ Gem::Specification.new do |s|
   s.summary     = %q{Simple key/secret based authentication for apis}
   s.description = %q{Simple key/secret based authentication for apis}
 
+
+  s.metadata['allowed_push_host'] = "https://rubygems.pkg.github.com/YourAcclaim"
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Just updates the gemspec to target this repo's Github package registry. Version updated to reflect both the update to the gemspec, but also I suppose the earlier update to handle nested hashes/arrays.