### PR TITLE
[WOR-4059] - Upgrade to ruby 3.2.3

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_BUILD__EVENTMACHINE: "--with-openssl-dir=/opt/homebrew/opt/openssl@3"

--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_BUILD__EVENTMACHINE: "--with-openssl-dir=/opt/homebrew/opt/openssl@3"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM public.ecr.aws/docker/library/ruby:3.2.3-alpine3.19
+
+RUN apk add --no-cache --update git build-base bash
+
+
+RUN echo "#!/bin/sh" >> /entrypoint.sh &&  \
+    echo 'exec "$@"' >>/entrypoint.sh && \
+    chmod +x /entrypoint.sh
+COPY signature.gemspec Gemfile Gemfile.lock /app/
+COPY lib/signature/version.rb /app/lib/signature/
+
+WORKDIR /app
+
+RUN gem update --system 3.3.26
+RUN gem install bundler:2.4.22
+
+RUN bundle install
+
+COPY . /app/
+
+ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    signature (0.1.9)
+    signature (1.0.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,32 @@
 PATH
   remote: .
   specs:
-    signature (0.1.8)
+    signature (0.1.9)
 
 GEM
   remote: https://rubygems.org/
   specs:
     bacon (1.2.0)
-    diff-lcs (1.2.4)
+    diff-lcs (1.5.1)
     em-spec (0.2.6)
       bacon
       eventmachine
       rspec (> 2.6.0)
       test-unit
     eventmachine (1.0.7)
-    rspec (2.13.0)
-      rspec-core (~> 2.13.0)
-      rspec-expectations (~> 2.13.0)
-      rspec-mocks (~> 2.13.0)
-    rspec-core (2.13.1)
-    rspec-expectations (2.13.0)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.13.1)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.0)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.0)
     test-unit (2.5.4)
 
 PLATFORMS
@@ -29,5 +34,8 @@ PLATFORMS
 
 DEPENDENCIES
   em-spec
-  rspec
+  rspec (~> 3.13.0)
   signature!
+
+BUNDLED WITH
+   2.4.22

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    signature (1.0.0)
+    signature (0.2.0)
 
 GEM
   remote: https://rubygems.org/
@@ -38,4 +38,4 @@ DEPENDENCIES
   signature!
 
 BUNDLED WITH
-   2.4.22
+   2.5.6

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,16 @@
+version: '3.5'
+
+services:
+  signature:
+    stdin_open: true
+    build:
+      dockerfile: Dockerfile
+      context: .
+    volumes:
+      - .:/app
+    command: "bash -c 'while true; do sleep 2; done'"
+    logging: &default-logging-options
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "5"

--- a/lib/signature/version.rb
+++ b/lib/signature/version.rb
@@ -1,3 +1,3 @@
 module Signature
-  VERSION = "0.1.9"
+  VERSION = "1.0.0"
 end

--- a/lib/signature/version.rb
+++ b/lib/signature/version.rb
@@ -1,3 +1,3 @@
 module Signature
-  VERSION = "1.0.0"
+  VERSION = "0.2.0"
 end

--- a/signature.gemspec
+++ b/signature.gemspec
@@ -21,6 +21,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "jruby-openssl" if defined?(JRUBY_VERSION)
-  s.add_development_dependency "rspec"
+  s.add_development_dependency "rspec", "~> 3.13.0"
   s.add_development_dependency "em-spec"
 end

--- a/spec/signature_spec.rb
+++ b/spec/signature_spec.rb
@@ -2,7 +2,7 @@ require File.expand_path('../spec_helper', __FILE__)
 
 describe Signature do
   before :each do
-    Time.stub!(:now).and_return(Time.at(1234))
+    allow(Time).to receive(:now).and_return(1234)
 
     @token = Signature::Token.new('key', 'secret')
 
@@ -20,28 +20,26 @@ describe Signature do
     it "should generate signature correctly" do
       @request.sign(@token)
       string = @request.send(:string_to_sign)
-      string.should == "POST\n/some/path\nauth_key=key&auth_timestamp=1234&auth_version=1.0&go=here&query=params"
+      expect(string).to eq("POST\n/some/path\nauth_key=key&auth_timestamp=1234&auth_version=1.0&go=here&query=params")
 
       digest = OpenSSL::Digest::SHA256.new
       signature = OpenSSL::HMAC.hexdigest(digest, @token.secret, string)
-      signature.should == @signature
+      expect(signature).to eq(@signature)
     end
 
     it "should make auth_hash available after request is signed" do
       @request.query_hash = {
         "query" => "params"
       }
-      lambda {
-        @request.auth_hash
-      }.should raise_error('Request not signed')
+      expect { @request.auth_hash }.to raise_error('Request not signed')
 
       @request.sign(@token)
-      @request.auth_hash.should == {
+      expect(@request.auth_hash).to eq({
         :auth_signature => "da078fcedd72941b6c873caa40d0d6b2000ebfc700cee802b128dd20f72e74e9",
         :auth_version => "1.0",
         :auth_key => "key",
         :auth_timestamp => '1234'
-      }
+      })
     end
 
     it "should cope with symbol keys" do
@@ -49,7 +47,7 @@ describe Signature do
         :query => "params",
         :go => "here"
       }
-      @request.sign(@token)[:auth_signature].should == @signature
+      expect(@request.sign(@token)[:auth_signature]).to eq(@signature)
     end
 
     it "should cope with upcase keys (keys are lowercased before signing)" do
@@ -57,31 +55,33 @@ describe Signature do
         "Query" => "params",
         "GO" => "here"
       }
-      @request.sign(@token)[:auth_signature].should == @signature
+      expect(@request.sign(@token)[:auth_signature]).to eq(@signature)
     end
 
     it "should generate correct string when query hash contains array" do
       @request.query_hash = {
         "things" => ["thing1", "thing2"]
       }
-      @request.send(:string_to_sign).should == "POST\n/some/path\nthings[]=thing1&things[]=thing2"
+      expect(@request.send(:string_to_sign)).to eq("POST\n/some/path\nthings[]=thing1&things[]=thing2")
     end
 
     it "should generate correct string when query hash contains nested elements" do
       @request.query_hash = {
         "things" => [{ "thing_1" => "value1" }, { "thing_2" => "value2" }]
       }
-      @request.send(:string_to_sign).should ==
+      expect(@request.send(:string_to_sign)).to eq(
         "POST\n/some/path\nthings[][thing_1]=value1&things[][thing_2]=value2"
+      )
     end
 
     it "should generate correct string when query hash contains nested arrays" do
       @request.query_hash = {
         "things" => [{ "thing_1" => [["v1", "v1"]] }, { "thing_2" => [["v2", "v2"]] }]
       }
-      @request.send(:string_to_sign).should ==
+      expect(@request.send(:string_to_sign)).to eq(
         "POST\n/some/path\nthings[][thing_1][][]=v1&things[][thing_1][][]=v1"\
         "&things[][thing_2][][]=v2&things[][thing_2][][]=v2"
+      )
     end
 
     # This may well change in auth version 2
@@ -89,26 +89,26 @@ describe Signature do
       @request.query_hash = {
         "key;" => "value@"
       }
-      @request.send(:string_to_sign).should == "POST\n/some/path\nkey;=value@"
+      expect(@request.send(:string_to_sign)).to eq("POST\n/some/path\nkey;=value@")
     end
 
     it "should cope with requests where the value is nil (antiregression)" do
       @request.query_hash = {
         "key" => nil
       }
-      @request.send(:string_to_sign).should == "POST\n/some/path\nkey="
+      expect(@request.send(:string_to_sign)).to eq("POST\n/some/path\nkey=")
     end
 
     it "should use the path to generate signature" do
       @request.path = '/some/other/path'
-      @request.sign(@token)[:auth_signature].should_not == @signature
+      expect(@request.sign(@token)[:auth_signature]).not_to eq(@signature)
     end
 
     it "should use the query string keys to generate signature" do
       @request.query_hash = {
         "other" => "query"
       }
-      @request.sign(@token)[:auth_signature].should_not == @signature
+      expect(@request.sign(@token)[:auth_signature]).not_to eq(@signature)
     end
 
     it "should use the query string values to generate signature" do
@@ -116,7 +116,7 @@ describe Signature do
         "key" => "notfoo",
         "other" => 'bar'
       }
-      @request.sign(@token)[:signature].should_not == @signature
+      expect(@request.sign(@token)[:signature]).not_to eq(@signature)
     end
   end
 
@@ -128,112 +128,112 @@ describe Signature do
 
     it "should verify requests" do
       request = Signature::Request.new('POST', '/some/path', @params)
-      request.authenticate_by_token(@token).should == true
+      expect(request.authenticate_by_token(@token)).to eq(true)
     end
 
     it "should raise error if signature is not correct" do
       @params[:auth_signature] =  'asdf'
       request = Signature::Request.new('POST', '/some/path', @params)
-      lambda {
+      expect {
         request.authenticate_by_token!(@token)
-      }.should raise_error('Invalid signature: you should have sent HmacSHA256Hex("POST\n/some/path\nauth_key=key&auth_timestamp=1234&auth_version=1.0&go=here&query=params", your_secret_key), but you sent "asdf"')
+      }.to raise_error('Invalid signature: you should have sent HmacSHA256Hex("POST\n/some/path\nauth_key=key&auth_timestamp=1234&auth_version=1.0&go=here&query=params", your_secret_key), but you sent "asdf"')
     end
 
     it "should raise error if timestamp not available" do
       @params.delete(:auth_timestamp)
       request = Signature::Request.new('POST', '/some/path', @params)
-      lambda {
+      expect {
         request.authenticate_by_token!(@token)
-      }.should raise_error('Timestamp required')
+      }.to raise_error('Timestamp required')
     end
 
     it "should raise error if timestamp has expired (default of 600s)" do
       request = Signature::Request.new('POST', '/some/path', @params)
-      Time.stub!(:now).and_return(Time.at(1234 + 599))
-      request.authenticate_by_token!(@token).should == true
-      Time.stub!(:now).and_return(Time.at(1234 - 599))
-      request.authenticate_by_token!(@token).should == true
-      Time.stub!(:now).and_return(Time.at(1234 + 600))
-      lambda {
+      allow(Time).to receive(:now).and_return(Time.at(1234 + 599))
+      expect(request.authenticate_by_token!(@token)).to eq(true)
+      allow(Time).to receive(:now).and_return(Time.at(1234 - 599))
+      expect(request.authenticate_by_token!(@token)).to eq(true)
+      allow(Time).to receive(:now).and_return(Time.at(1234 + 600))
+      expect {
         request.authenticate_by_token!(@token)
-      }.should raise_error("Timestamp expired: Given timestamp (1970-01-01T00:20:34Z) not within 600s of server time (1970-01-01T00:30:34Z)")
-      Time.stub!(:now).and_return(Time.at(1234 - 600))
-      lambda {
+      }.to raise_error("Timestamp expired: Given timestamp (1970-01-01T00:20:34Z) not within 600s of server time (1970-01-01T00:30:34Z)")
+      allow(Time).to receive(:now).and_return(Time.at(1234 - 600))
+      expect {
         request.authenticate_by_token!(@token)
-      }.should raise_error("Timestamp expired: Given timestamp (1970-01-01T00:20:34Z) not within 600s of server time (1970-01-01T00:10:34Z)")
+      }.to raise_error("Timestamp expired: Given timestamp (1970-01-01T00:20:34Z) not within 600s of server time (1970-01-01T00:10:34Z)")
     end
 
     it "should be possible to customize the timeout grace period" do
       grace = 10
       request = Signature::Request.new('POST', '/some/path', @params)
-      Time.stub!(:now).and_return(Time.at(1234 + grace - 1))
-      request.authenticate_by_token!(@token, grace).should == true
-      Time.stub!(:now).and_return(Time.at(1234 + grace))
-      lambda {
+      allow(Time).to receive(:now).and_return(Time.at(1234 + grace - 1))
+      expect(request.authenticate_by_token!(@token, grace)).to eq(true)
+      allow(Time).to receive(:now).and_return(Time.at(1234 + grace))
+      expect {
         request.authenticate_by_token!(@token, grace)
-      }.should raise_error("Timestamp expired: Given timestamp (1970-01-01T00:20:34Z) not within 10s of server time (1970-01-01T00:20:44Z)")
+      }.to raise_error("Timestamp expired: Given timestamp (1970-01-01T00:20:34Z) not within 10s of server time (1970-01-01T00:20:44Z)")
     end
 
     it "should be possible to skip timestamp check by passing nil" do
       request = Signature::Request.new('POST', '/some/path', @params)
-      Time.stub!(:now).and_return(Time.at(1234 + 1000))
-      request.authenticate_by_token!(@token, nil).should == true
+      allow(Time).to receive(:now).and_return(Time.at(1234 + 1000))
+      expect(request.authenticate_by_token!(@token, nil)).to eq(true)
     end
-    
+
     it "should check that auth_version is supplied" do
       @params.delete(:auth_version)
       request = Signature::Request.new('POST', '/some/path', @params)
-      lambda {
+      expect {
         request.authenticate_by_token!(@token)
-      }.should raise_error('Version required')
+      }.to raise_error('Version required')
     end
 
     it "should check that auth_version equals 1.0" do
       @params[:auth_version] = '1.1'
       request = Signature::Request.new('POST', '/some/path', @params)
-      lambda {
+      expect {
         request.authenticate_by_token!(@token)
-      }.should raise_error('Version not supported')
+      }.to raise_error('Version not supported')
     end
 
     it "should validate that the provided token has a non-empty secret" do
       token = Signature::Token.new('key', '')
       request = Signature::Request.new('POST', '/some/path', @params)
 
-      lambda {
+      expect {
         request.authenticate_by_token!(token)
-      }.should raise_error('Provided token is missing secret')
+      }.to raise_error('Provided token is missing secret')
     end
 
     describe "when used with optional block" do
       it "should optionally take a block which yields the signature" do
         request = Signature::Request.new('POST', '/some/path', @params)
-        request.authenticate do |key|
-          key.should == @token.key
+        expect(request.authenticate do |key|
+          expect(key).to eq(@token.key)
           @token
-        end.should == @token
+        end).to eq(@token)
       end
 
       it "should raise error if no auth_key supplied to request" do
         @params.delete(:auth_key)
         request = Signature::Request.new('POST', '/some/path', @params)
-        lambda {
+        expect {
           request.authenticate { |key| nil }
-        }.should raise_error('Missing parameter: auth_key')
+        }.to raise_error('Missing parameter: auth_key')
       end
 
       it "should raise error if block returns nil (i.e. key doesn't exist)" do
         request = Signature::Request.new('POST', '/some/path', @params)
-        lambda {
+        expect {
           request.authenticate { |key| nil }
-        }.should raise_error('Unknown auth_key')
+        }.to raise_error('Unknown auth_key')
       end
 
       it "should raise unless block given" do
         request = Signature::Request.new('POST', '/some/path', @params)
-        lambda {
+        expect {
           request.authenticate
-        }.should raise_error(ArgumentError, "Block required")
+        }.to raise_error(ArgumentError, "Block required")
       end
     end
 
@@ -253,7 +253,7 @@ describe Signature do
           df.succeed(@token)
 
           request_df.callback { |token|
-            token.should == @token
+            expect(token).to eq(@token)
             done
           }
         }
@@ -271,8 +271,8 @@ describe Signature do
           df.fail()
 
           request_df.errback { |e|
-            e.class.should == Signature::AuthenticationError
-            e.message.should == 'Unknown auth_key'
+            expect(e.class).to eq(Signature::AuthenticationError)
+            expect(e.message).to eq('Unknown auth_key')
             done
           }
         }
@@ -291,8 +291,8 @@ describe Signature do
           df.succeed(token)
 
           request_df.errback { |e|
-            e.class.should == Signature::AuthenticationError
-            e.message.should =~ /Invalid signature/
+            expect(e.class).to eq(Signature::AuthenticationError)
+            expect(e.message).to match(/Invalid signature/)
             done
           }
         }


### PR DESCRIPTION
https://wfspearson.atlassian.net/browse/WOR-4059

This PR upgrades the rspec version (latest). I didn’t see a reason to not to go to latest version but I did had to upgrade it since ruby don’t implement the method `exists?` anymore. The specs were updated to work with the newest rspec.

<img width="1440" alt="Screenshot 2024-02-14 at 17 47 12" src="https://github.com/YourAcclaim/signature/assets/17296780/01d5b03d-5db6-4efd-b4a0-c0b1a15ef277">

I also added a Dockerfile and docker-compose because I had issues installing `eventmachine v1.0.7` natively (I believe this has something to do with my M1 Sonoma MacOS since it works without any issues in ruby:3.2.3-alpine3.19 docker image).
I don’t think the docker is 100% necessary but this is the way I found to be able to run the tests locally.

Tests passing:
<img width="1424" alt="Screenshot 2024-02-14 at 14 54 43" src="https://github.com/YourAcclaim/signature/assets/17296780/c8f249f6-73f7-402b-bba5-841222198324">
