### PR TITLE
chore: [CRED-6793] Upgrade signature to ruby 3.4.8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/docker/library/ruby:3.2.3-alpine3.19
+FROM public.ecr.aws/docker/library/ruby:3.4.8-alpine
 
 RUN apk add --no-cache --update git build-base bash
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    signature (0.2.0)
+    signature (0.2.1)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 signature
 =========
 
-[![Build Status](https://secure.travis-ci.org/mloughran/signature.png?branch=master)](http://travis-ci.org/mloughran/signature)
-
 Examples
 --------
 
@@ -56,8 +54,6 @@ Developing
 
     bundle
     bundle exec rspec spec/*_spec.rb
-
-Please see the travis status for a list of rubies tested against
 
 Docker Development
 ------------------

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ Developing
 
 Please see the travis status for a list of rubies tested against
 
+Docker Development
+------------------
+
+Build and start the container:
+
+    docker compose -f docker-compose.dev.yml up --build -d
+
+Run tests:
+
+    docker compose -f docker-compose.dev.yml exec signature bundle exec rspec
+
+
 Copyright
 ---------
 

--- a/lib/signature/query_encoder.rb
+++ b/lib/signature/query_encoder.rb
@@ -30,7 +30,7 @@ module Signature
       end
 
       def entry(key, value)
-        query_key = key.inject('') do |memo, part|
+        query_key = key.inject(String.new) do |memo, part|
           if part.nil?
             memo << "[]"
           else

--- a/lib/signature/version.rb
+++ b/lib/signature/version.rb
@@ -1,3 +1,3 @@
 module Signature
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end


### PR DESCRIPTION
What does this PR do?
- Updates the Ruby image version, increments version, adds Docker dev to the readme, fixes a String literal mutation in prep for when all string literals are frozen in a future version or Ruby. 
- When testing internal gems in `credly_messenger` I was seeing this warning: `/usr/local/bundle/gems/signature-0.2.0/lib/signature/query_encoder.rb:39: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information)`
- Tracked it down and experimented, used `String.new` instead of `''` so we inject a mutable string instead of a string literal (which will be frozen by default in future versions). I didn't see anything else I felt was concerning. The below is how I tested the small code change to ensure we weren't mutating a non-mutable string.
<img width="735" height="208" alt="image" src="https://github.com/user-attachments/assets/82253f35-cdc0-4247-bc80-3f3d86f89fac" />

How was this PR tested?
- Existing unit tests - only warnings are from dev only dependency gem used for testing, which looks like it's no longer maintained, and we are using the latest available version/tag ([em-spec](https://github.com/joshbuddy/em-spec)) 😬. So we should be OK:
<img width="1204" height="185" alt="image" src="https://github.com/user-attachments/assets/7e1664e1-cf23-425d-be0b-0d8b40fa106a" />
